### PR TITLE
Update the app's Ruby dependencies - January 2023

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -14,21 +14,21 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.6)
-    concurrent-ruby (1.1.10)
+    commonmarker (0.23.7)
+    concurrent-ruby (1.2.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (2.6.0)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.0)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -83,7 +83,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (>= 3.0, < 5.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.14.2)
+    html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
@@ -202,17 +202,17 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.8.1)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.16.3)
-    nokogiri (1.13.10)
+    minitest (5.17.0)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -221,7 +221,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.6.1)
+    racc (1.6.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -252,7 +252,7 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
@@ -265,4 +265,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.13
+   2.4.5


### PR DESCRIPTION
* activesupport 6.0.6 → 6.0.6.1 [changelog](https://github.com/rails/rails/blob/v7.0.4.1/activesupport/CHANGELOG.md)

* commonmarker 0.23.6 → 0.23.7 [changelog](https://github.com/gjtorikian/commonmarker/blob/main/CHANGELOG.md#v0237pre1-2022-11-14)

* concurrent-ruby 1.1.10 → 1.2.0 [changelog](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v120-23-jan-2023)

* ethon 0.15.0 → 0.16.0 [changelog](https://github.com/typhoeus/ethon/blob/master/CHANGELOG.md#0160)

* faraday 2.6.0 → 2.7.4 [changelog](https://github.com/lostisland/faraday/releases)

* faraday-net_http 3.0.0 → 3.0.2

* html-pipeline 2.14.2 → 2.14.3 [changelog](https://github.com/gjtorikian/html-pipeline/blob/main/CHANGELOG.md#v2143-2022-10-14)

* listen 3.7.1 → 3.8.0 [changelog](https://github.com/guard/listen/releases/tag/v3.8.0)

* mini_portile2 2.8.0 → 2.8.1 [changelog](https://github.com/flavorjones/mini_portile/blob/main/CHANGELOG.md#281--2022-12-24)

* minitest 5.16.3 → 5.17.0 [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc#5170--2022-12-31-)

* nokogiri 1.13.8 → 1.14.0 [changelog](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#1140--2023-01-12)

* racc 1.6.0 → 1.6.2 [changelog](https://github.com/ruby/racc/blob/master/ChangeLog)

* zeitwerk 2.6.1 → 2.6.6 [changelog](https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md#266-8-november-2022)