### PR TITLE
Upgrade Ruby to v3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '>= 3.0.3'
+ruby '>= 3.3.0'
 
 # gem 'jekyll-coffeescript'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.5)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -224,7 +223,6 @@ GEM
     net-http (0.4.1)
       uri
     nokogiri (1.16.2)
-      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -271,7 +269,7 @@ DEPENDENCIES
   webrick (~> 1.8)
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.5
+   2.5.6


### PR DESCRIPTION
* ruby 3.0.3 → 3.3.0
[announcement](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)