### PR TITLE
Update the app's dependencies - July 2024

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.2)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -11,19 +11,19 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.8)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
     commonmarker (0.23.10)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
-    dnsruby (1.70.0)
+    dnsruby (1.72.2)
       simpleidn (~> 0.2.1)
     drb (2.2.1)
     em-websocket (0.5.3)
@@ -33,11 +33,12 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.9.1)
-    faraday (2.9.0)
+    faraday (2.10.0)
       faraday-net_http (>= 2.0, < 3.2)
+      logger
     faraday-net_http (3.1.0)
       net-http
-    ffi (1.16.3)
+    ffi (1.17.0)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (231)
@@ -95,7 +96,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     jekyll (3.9.5)
       addressable (~> 2.4)
@@ -213,28 +214,27 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     mercenary (0.3.6)
-    mini_portile2 (2.8.6)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.22.2)
+    minitest (5.24.1)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    nokogiri (1.16.5)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.6)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.4)
-    racc (1.7.3)
+    public_suffix (5.1.1)
+    racc (1.8.0)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.3.2)
       strscan
@@ -249,8 +249,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    simpleidn (0.2.1)
-      unf (~> 0.1.4)
+    simpleidn (0.2.3)
     strscan (3.1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -258,9 +257,6 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
     uri (0.13.0)
     webrick (1.8.1)
@@ -276,4 +272,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.6
+   2.5.14


### PR DESCRIPTION
* activesupport 7.1.3.2 → 7.1.3.4 [changelog](https://github.com/rails/rails/blob/v7.1.3.4/activesupport/CHANGELOG.md#rails-7134-june-04-2024)

* addressable 2.8.6 → 2.8.7 [changelog](https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md#v2.8.7)

* bigdecimal 3.1.6 → 3.1.8 [changelog](https://github.com/ruby/bigdecimal/blob/master/CHANGES.md#318)

* concurrent-ruby 1.2.3 → 1.3.3 [changelog](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v133-9-june-2024)

* dnsruby 1.70.0 → 1.72.2 [changelog](https://github.com/alexdalitz/dnsruby/blob/master/RELEASE_NOTES.md#v1722)

* faraday 2.9.0 → 2.10.0 [changelog](https://github.com/lostisland/faraday/releases/tag/v2.10.0)

* ffi 1.16.3 → 1.17.0 [changelog](https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1170--2024-06-02)

* i18n 1.14.4 → 1.14.5 [changelog](https://github.com/ruby-i18n/i18n/releases)

* minitest 5.22.2 → 5.24.1 [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc#5241--2024-06-29-)

* nokogiri 1.16.5 → 1.16.6 [changelog](https://nokogiri.org/CHANGELOG.html)

* public_suffix 5.0.4 → 5.1.1 [changelog](https://github.com/weppos/publicsuffix-ruby/blob/master/CHANGELOG.md#511)

* racc 1.7.3 → 1.8.0

* rb-inotify 0.10.1 → 0.11.1

* simpleidn 0.2.1 → 0.2.3