### PR TITLE
Update the app's dependencies - April 2025

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.1)
+    activesupport (8.0.2)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -26,8 +26,8 @@ GEM
     colorator (1.1.0)
     commonmarker (0.23.11)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
-    csv (3.3.2)
+    connection_pool (2.5.3)
+    csv (3.3.4)
     dnsruby (1.72.4)
       base64 (~> 0.2.0)
       logger (~> 1.6.5)
@@ -40,13 +40,13 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.12.2)
+    faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.1)
+    ffi (1.17.2)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -217,7 +217,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.10.2)
+    json (2.11.3)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -233,7 +233,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.25.4)
+    minitest (5.25.5)
     net-http (0.6.0)
       uri
     nokogiri (1.18.8)
@@ -284,4 +284,4 @@ RUBY VERSION
    ruby 3.4.2p28
 
 BUNDLED WITH
-   2.6.5
+   2.6.8


### PR DESCRIPTION
* activesupport 8.0.1 → 8.0.2 [changelog](https://github.com/rails/rails/blob/v8.0.2/activesupport/CHANGELOG.md#rails-802-march-12-2025)

* connection_pool 2.5.0 → 2.5.3 [changelog](https://github.com/mperham/connection_pool/blob/main/Changes.md#253)

* csv 3.3.2 → 3.3.4 [changelog](https://github.com/ruby/csv/releases/tag/v3.3.4)

* faraday 2.12.2 → 2.13.1 [changelog](https://github.com/lostisland/faraday/releases/tag/v2.13.1)

* ffi 1.17.1 → 1.17.2 [changelog](https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1172--2025-04-15)

* json 2.10.2 → 2.11.3 [changelog](https://github.com/ruby/json/blob/master/CHANGES.md#2025-04-25-2113)

* minitest 5.25.4 → 5.25.5 [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc#5255--2025-03-12-)