### PR TITLE
Update the app's dependencies - July 2025

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -27,12 +27,12 @@ GEM
     commonmarker (0.23.11)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    csv (3.3.4)
+    csv (3.3.5)
     dnsruby (1.72.4)
       base64 (~> 0.2.0)
       logger (~> 1.6.5)
       simpleidn (~> 0.2.1)
-    drb (2.2.1)
+    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -40,11 +40,11 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.13.1)
+    faraday (2.13.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     ffi (1.17.2)
     forwardable-extended (2.6.0)
@@ -217,7 +217,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.11.3)
+    json (2.13.0)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
* benchmark 0.4.0 → 0.4.1 [changelog](https://github.com/ruby/benchmark/releases/tag/v0.4.1)

* bigdecimal 3.1.9 → 3.2.2 [changelog](https://github.com/ruby/bigdecimal/blob/master/CHANGES.md#322)

* csv 3.3.4 → 3.3.5 [changelog](https://github.com/ruby/csv/releases/tag/v3.3.5)

* drb 2.2.1 → 2.2.3 [changelog](https://github.com/ruby/drb/releases/tag/v2.2.3)

* faraday 2.13.1 → 2.13.3 [changelog](https://github.com/lostisland/faraday/releases/tag/v2.13.3)

* faraday-net_http 3.4.0 → 3.4.1 [changelog](https://github.com/lostisland/faraday-net_http/releases/tag/v3.4.1)

* json 2.11.3 → 2.13.0 [changelog](https://github.com/ruby/json/blob/master/CHANGES.md#2025-05-23-2130)