### PR TITLE
Update the app's dependencies - June 2026

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4)
     forwardable-extended (2.6.0)
@@ -217,7 +217,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.19.8)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -234,7 +234,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     net-http (0.9.1)
@@ -288,4 +288,4 @@ RUBY VERSION
   ruby 3.4.9
 
 BUNDLED WITH
-  4.0.10
+  4.0.14


### PR DESCRIPTION
* faraday-net_http 3.4.2 → 3.4.4 [changelog](https://github.com/lostisland/faraday-net_http/releases/tag/v3.4.4)

* json 2.19.5 → 2.19.8 [changelog](https://github.com/ruby/json/blob/master/CHANGES.md#2026-06-03-2198)

* minitest 6.0.5 → 6.0.6 [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc#606--2026-04-30)